### PR TITLE
Fixed compile time error

### DIFF
--- a/src/net_server.c
+++ b/src/net_server.c
@@ -45,6 +45,8 @@
 // How often to re-resolve the address of the master server?
 #define MASTER_RESOLVE_PERIOD 8 * 60 * 60 /* 8 hours */
 
+char *sv_player_names[NET_MAXPLAYERS];
+
 typedef enum
 {
     // waiting for the game to be "launched" (key player to press the start

--- a/src/net_server.h
+++ b/src/net_server.h
@@ -16,7 +16,7 @@
 
 #ifndef NET_SERVER_H
 #define NET_SERVER_H
-char *sv_player_names[NET_MAXPLAYERS];
+extern char *sv_player_names[NET_MAXPLAYERS];
 
 // initialize server and wait for connections
 


### PR DESCRIPTION
The chocolate doom server would not compile due to multiple definitions of `char* playerNames[MAXPLAYERS]` in the `src/net_dedicated.c` and `sec/net_server.c` files due to both including `src/net_server.h`.
`extern`ing the string array in `src/net_server.h` and defining it in `src/net_server.c` fixed the compile time errors.
